### PR TITLE
OIDC and Identity Center Permissions

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: aee9edb
+_commit: e8a117e
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_org_home_region: us-east-1

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: f2e9a54
+_commit: 133d431
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_production_account_id: 038462771856

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: e8a117e
+_commit: 4c1d803
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_org_home_region: us-east-1

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 853f2ae
+_commit: 8feb395
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_production_account_id: 038462771856

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,8 @@
 # Changes here will be overwritten by Copier
-_commit: 133d431
+_commit: aee9edb
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
+aws_org_home_region: us-east-1
 aws_production_account_id: 038462771856
 central_infra_github_organization_name: ejfine
 description: Manage central infra for this AWS org

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: e91cd7c
+_commit: 0cc14d0
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_production_account_id: 038462771856

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,10 +1,11 @@
 # Changes here will be overwritten by Copier
-_commit: '1910203'
+_commit: 02cfe12
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_production_account_id: 038462771856
 central_infra_github_organization_name: ejfine
 description: Manage central infra for this AWS org
+initial_iac_management_deploy_occurred: true
 python_version: 3.13.1
 repo_name: aws-central-infrastructure
 ssh_port_number: 52368

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 4a2edc6
+_commit: f2e9a54
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_production_account_id: 038462771856

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 02cfe12
+_commit: 08238e8
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_production_account_id: 038462771856

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 46b33a9
+_commit: 853f2ae
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_production_account_id: 038462771856

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,10 +1,11 @@
 # Changes here will be overwritten by Copier
-_commit: 08238e8
+_commit: 4a2edc6
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_production_account_id: 038462771856
 central_infra_github_organization_name: ejfine
 description: Manage central infra for this AWS org
+identity_center_production_account_id: '872515268414'
 initial_iac_management_deploy_occurred: true
 python_version: 3.13.1
 repo_name: aws-central-infrastructure

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 0cc14d0
+_commit: '1910203'
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_production_account_id: 038462771856

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 8feb395
+_commit: a016f2a
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_production_account_id: 038462771856

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: cda29c9
+_commit: '4934082'
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_production_account_id: 038462771856

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: a016f2a
+_commit: e91cd7c
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_production_account_id: 038462771856

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,8 +1,9 @@
 # Changes here will be overwritten by Copier
-_commit: '4934082'
+_commit: 46b33a9
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_production_account_id: 038462771856
+central_infra_github_organization_name: ejfine
 description: Manage central infra for this AWS org
 python_version: 3.13.1
 repo_name: aws-central-infrastructure

--- a/.devcontainer/create-aws-profile.sh
+++ b/.devcontainer/create-aws-profile.sh
@@ -3,9 +3,15 @@ set -ex
 
 mkdir -p ~/.aws
 cat >> ~/.aws/config <<EOF
-[profile development]
+[profile central-infra]
 sso_session = org
 sso_account_id = 038462771856
+sso_role_name = LowRiskAccountAdminAccess
+region = us-east-1
+
+[profile identity-center]
+sso_session = org
+sso_account_id = 872515268414
 sso_role_name = LowRiskAccountAdminAccess
 region = us-east-1
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,13 +62,27 @@ jobs:
       PULUMI_UP_ROLE_NAME: InfraDeploy--aws-central-infrastructure
       AWS_ACCOUNT_ID: "038462771856"
 
+  identity-center-pulumi:
+    uses: ./.github/workflows/pulumi-aws.yml
+    needs: [ iac-management-pulumi ]
+    with:
+      AWS_REGION: us-east-1
+      PULUMI_STACK_NAME: prod
+      PYTHON_VERSION: 3.13.1
+      DEPLOY_SCRIPT_MODULE_NAME: aws_central_infrastructure
+      DEPLOY_SCRIPT_NAME: deploy_identity_center
+      PULUMI_PREVIEW: true
+      PREVIEW_ROLE_NAME: InfraPreview--aws-central-infrastructure--identity-center
+      PULUMI_UP: ${{ github.ref == 'refs/heads/main' }}
+      PULUMI_UP_ROLE_NAME: InfraDeploy--aws-central-infrastructure--identity-center
+      AWS_ACCOUNT_ID: "872515268414"
 
   required-check:
     runs-on: ubuntu-24.04
-    needs: [ lint, iac-management-pulumi ]
+    needs: [ lint, iac-management-pulumi, identity-center-pulumi ]
     if: always()
     steps:
       - name: fail if prior job failure
-        if: needs.lint.result != 'success' || needs.iac-management-pulumi.result != 'success'
+        if: needs.lint.result != 'success' || needs.iac-management-pulumi.result != 'success' || needs.identity-center-pulumi.result != 'success'
         run: |
           exit 1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 
 # Using Pulumi
-Run a Pulumi Preview: `uv run python -m aws_central_infrastructure.deploy_iac_management --stack=dev`
+Run a Pulumi Preview for the IaC Management project: `uv run python -m aws_central_infrastructure.deploy_iac_management --stack=prod`
+Run a Pulumi Preview for the Identity Center project: `uv run python -m aws_central_infrastructure.deploy_identity_center --stack=prod`
 
 
 ## Updating from the template

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "ephemeral-pulumi-deploy>=0.0.1",
     "boto3>=1.36.3",
     "boto3-stubs[all]>=1.36.3",
+    "pydantic>=2.10.6",
 ]
 
 [tool.uv]

--- a/src/aws_central_infrastructure/constants.py
+++ b/src/aws_central_infrastructure/constants.py
@@ -1,0 +1,2 @@
+CENTRAL_INFRA_REPO_NAME = "aws-central-infrastructure"
+CENTRAL_INFRA_GITHUB_ORG_NAME = "ejfine"

--- a/src/aws_central_infrastructure/constants.py
+++ b/src/aws_central_infrastructure/constants.py
@@ -1,3 +1,2 @@
 CENTRAL_INFRA_REPO_NAME = "aws-central-infrastructure"
 CENTRAL_INFRA_GITHUB_ORG_NAME = "ejfine"
-AWS_ORG_HOME_REGION = "us-east-1"

--- a/src/aws_central_infrastructure/constants.py
+++ b/src/aws_central_infrastructure/constants.py
@@ -1,2 +1,3 @@
 CENTRAL_INFRA_REPO_NAME = "aws-central-infrastructure"
 CENTRAL_INFRA_GITHUB_ORG_NAME = "ejfine"
+AWS_ORG_HOME_REGION = "us-east-1"

--- a/src/aws_central_infrastructure/deploy_iac_management.py
+++ b/src/aws_central_infrastructure/deploy_iac_management.py
@@ -14,6 +14,7 @@ def generate_stack_config() -> dict[str, Any]:
     """Generate the stack configuration."""
     stack_config: dict[str, Any] = {}
     stack_config["proj:pulumi_project_name"] = "iac-management"
+    stack_config["proj:aws_org_home_region"] = ConfigValue(value="us-east-1")
     github_repo_name = "aws-central-infrastructure"
     stack_config["proj:github_repo_name"] = github_repo_name
 

--- a/src/aws_central_infrastructure/deploy_iac_management.py
+++ b/src/aws_central_infrastructure/deploy_iac_management.py
@@ -9,6 +9,7 @@ from .iac_management.program import pulumi_program
 logger = logging.getLogger(__name__)
 
 
+# pylint:disable=duplicate-code # there's not much to DRY up here, it's some commonalities between the two deploy scripts
 def generate_stack_config() -> dict[str, Any]:
     """Generate the stack configuration."""
     stack_config: dict[str, Any] = {}

--- a/src/aws_central_infrastructure/deploy_identity_center.py
+++ b/src/aws_central_infrastructure/deploy_identity_center.py
@@ -4,7 +4,7 @@ from typing import Any
 from ephemeral_pulumi_deploy import run_cli
 from pulumi.automation import ConfigValue
 
-from .iac_management.program import pulumi_program
+from .identity_center.program import pulumi_program
 
 logger = logging.getLogger(__name__)
 

--- a/src/aws_central_infrastructure/deploy_identity_center.py
+++ b/src/aws_central_infrastructure/deploy_identity_center.py
@@ -1,0 +1,28 @@
+import logging
+from typing import Any
+
+from ephemeral_pulumi_deploy import run_cli
+from pulumi.automation import ConfigValue
+
+from .iac_management.program import pulumi_program
+
+logger = logging.getLogger(__name__)
+
+
+def generate_stack_config() -> dict[str, Any]:
+    """Generate the stack configuration."""
+    stack_config: dict[str, Any] = {}
+    stack_config["proj:pulumi_project_name"] = "identity-center"
+    github_repo_name = "aws-central-infrastructure"
+    stack_config["proj:github_repo_name"] = github_repo_name
+
+    stack_config["proj:git_repository_url"] = ConfigValue(value=f"https://github.com/ejfine/{github_repo_name}")
+    return stack_config
+
+
+def main() -> None:
+    run_cli(stack_config=generate_stack_config(), pulumi_program=pulumi_program)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aws_central_infrastructure/deploy_identity_center.py
+++ b/src/aws_central_infrastructure/deploy_identity_center.py
@@ -14,6 +14,7 @@ def generate_stack_config() -> dict[str, Any]:
     """Generate the stack configuration."""
     stack_config: dict[str, Any] = {}
     stack_config["proj:pulumi_project_name"] = "identity-center"
+    stack_config["proj:aws_org_home_region"] = ConfigValue(value="us-east-1")
     github_repo_name = "aws-central-infrastructure"
     stack_config["proj:github_repo_name"] = github_repo_name
 

--- a/src/aws_central_infrastructure/deploy_identity_center.py
+++ b/src/aws_central_infrastructure/deploy_identity_center.py
@@ -9,6 +9,7 @@ from .identity_center.program import pulumi_program
 logger = logging.getLogger(__name__)
 
 
+# pylint:disable=duplicate-code # there's not much to DRY up here, it's some commonalities between the two deploy scripts
 def generate_stack_config() -> dict[str, Any]:
     """Generate the stack configuration."""
     stack_config: dict[str, Any] = {}

--- a/src/aws_central_infrastructure/iac_management/github_oidc.py
+++ b/src/aws_central_infrastructure/iac_management/github_oidc.py
@@ -1,0 +1,28 @@
+from collections import defaultdict
+
+from ..constants import CENTRAL_INFRA_GITHUB_ORG_NAME
+from ..constants import CENTRAL_INFRA_REPO_NAME
+from .github_oidc_lib import GithubOidcConfig
+from .github_oidc_lib import WorkloadName
+from .github_oidc_lib import create_oidc_for_single_account_workload
+from .shared_lib import AwsLogicalWorkload
+
+
+def generate_all_oidc(
+    *, workloads_info: dict[WorkloadName, AwsLogicalWorkload], kms_key_arn: str
+) -> dict[WorkloadName, list[GithubOidcConfig]]:
+    all_oidc: dict[WorkloadName, list[GithubOidcConfig]] = defaultdict(list)
+
+    workload_name = "identity-center"
+    identity_center_workload = workloads_info[workload_name]
+    all_oidc[workload_name].extend(
+        create_oidc_for_single_account_workload(
+            aws_account_id=identity_center_workload.prod_accounts[0].id,
+            repo_org=CENTRAL_INFRA_GITHUB_ORG_NAME,
+            repo_name=CENTRAL_INFRA_REPO_NAME,
+            kms_key_arn=kms_key_arn,
+            role_name_suffix="identity-center",
+        )
+    )
+
+    return all_oidc

--- a/src/aws_central_infrastructure/iac_management/github_oidc_lib.py
+++ b/src/aws_central_infrastructure/iac_management/github_oidc_lib.py
@@ -1,0 +1,171 @@
+from ephemeral_pulumi_deploy.utils import common_tags_native
+from pulumi import ComponentResource
+from pulumi import Output
+from pulumi import ResourceOptions
+from pulumi_aws.iam import GetPolicyDocumentStatementArgs
+from pulumi_aws.iam import GetPolicyDocumentStatementConditionArgs
+from pulumi_aws.iam import GetPolicyDocumentStatementPrincipalArgs
+from pulumi_aws.iam import get_policy_document
+from pulumi_aws_native import Provider
+from pulumi_aws_native import iam
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+
+from .shared_lib import AwsLogicalWorkload
+
+type WorkloadName = str
+type AwsAccountId = str
+
+
+class GithubOidcConfig(BaseModel):
+    aws_account_id: str
+    role_name: str
+    repo_org: str
+    repo_name: str
+    managed_policy_arns: list[str] = Field(default_factory=list)
+    restrictions: str | None = None
+    role_policy: iam.RolePolicyArgs | None = None
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+def create_oidc_for_single_account_workload(
+    *,
+    aws_account_id: str,
+    repo_org: str,
+    repo_name: str,
+    kms_key_arn: str,
+    role_name_suffix: str
+    | None = None,  # Used when there may be multiple separate stacks using different OIDC roles in the same repo.
+) -> list[GithubOidcConfig]:
+    role_name_ending = repo_name
+    if role_name_suffix is not None:
+        role_name_ending += f"--{role_name_suffix}"
+    kms_policy = iam.RolePolicyArgs(
+        policy_name="InfraKmsDecrypt",
+        policy_document=get_policy_document(
+            statements=[
+                GetPolicyDocumentStatementArgs(
+                    effect="Allow",
+                    actions=[
+                        "kms:Decrypt",
+                        "kms:Encrypt",  # unclear why Encrypt is required to run a Preview...but Pulumi gives an error if it's not included
+                    ],
+                    resources=[kms_key_arn],
+                )
+            ]
+        ).json,
+    )
+    return [
+        GithubOidcConfig(
+            aws_account_id=aws_account_id,
+            role_name=f"InfraDeploy--{role_name_ending}",
+            repo_org=repo_org,
+            repo_name=repo_name,
+            restrictions="ref:refs/heads/main",
+            managed_policy_arns=["arn:aws:iam::aws:policy/AdministratorAccess"],
+            role_policy=kms_policy,
+        ),
+        GithubOidcConfig(
+            aws_account_id=aws_account_id,
+            role_name=f"InfraPreview--{role_name_ending}",
+            repo_org=repo_org,
+            repo_name=repo_name,
+            managed_policy_arns=["arn:aws:iam::aws:policy/ReadOnlyAccess"],
+            role_policy=kms_policy,
+        ),
+    ]
+
+
+def find_account_name_from_workload_info(*, workload_info: AwsLogicalWorkload, account_id: str) -> str:
+    for account in workload_info.prod_accounts:
+        if account.id == account_id:
+            return account.name
+    for account in workload_info.staging_accounts:
+        if account.id == account_id:
+            return account.name
+    for account in workload_info.dev_accounts:
+        if account.id == account_id:
+            return account.name
+    raise ValueError(f"Could not find account with id {account_id} in workload {workload_info.name}")  # noqa: TRY003 # not worth a custom exception for this
+
+
+class WorkloadGithubOidc(ComponentResource):
+    def __init__(
+        self,
+        workload_info: AwsLogicalWorkload,
+        oidc_configs: list[GithubOidcConfig],
+        providers: dict[AwsAccountId, Provider],
+    ):
+        super().__init__("labauto:AwsWorkloadGithubOidc", workload_info.name, None)
+        all_aws_accounts: list[
+            str
+        ] = []  # use a list instead of a set for deterministic ordering to avoid false positive pulumi diffs. # TODO: consider just creating a sorted list after using a set initially
+        for oidc_config in oidc_configs:
+            if oidc_config.aws_account_id not in all_aws_accounts:
+                all_aws_accounts.append(oidc_config.aws_account_id)
+        oidc_providers: dict[AwsAccountId, iam.OidcProvider] = {}
+        for aws_account_id in all_aws_accounts:
+            account_name = find_account_name_from_workload_info(workload_info=workload_info, account_id=aws_account_id)
+            oidc_providers[aws_account_id] = iam.OidcProvider(
+                f"github-oidc-provider-{account_name}",
+                url="https://token.actions.githubusercontent.com",
+                client_id_list=["sts.amazonaws.com"],
+                thumbprint_list=["6938fd4d98bab03faadb97b34396831e3780aea1"],  # GitHub's root CA thumbprint
+                tags=common_tags_native(),
+                opts=ResourceOptions(provider=providers[aws_account_id], parent=self),
+            )
+        for oidc_config in oidc_configs:
+            assume_role_policy_doc = Output.all(
+                oidc_config=Output.from_input(oidc_config),
+                oidc_provider_arn=oidc_providers[oidc_config.aws_account_id].arn,
+            ).apply(
+                lambda args: get_policy_document(
+                    statements=[
+                        GetPolicyDocumentStatementArgs(
+                            effect="Allow",
+                            principals=[
+                                GetPolicyDocumentStatementPrincipalArgs(
+                                    type="Federated", identifiers=[args["oidc_provider_arn"]]
+                                )
+                            ],
+                            actions=["sts:AssumeRoleWithWebIdentity"],
+                            conditions=[
+                                GetPolicyDocumentStatementConditionArgs(
+                                    test="StringLike" if args["oidc_config"].restrictions is None else "StringEquals",
+                                    variable="token.actions.githubusercontent.com:sub",
+                                    values=[
+                                        f"repo:{args['oidc_config'].repo_org}/{args['oidc_config'].repo_name}:{'*' if args['oidc_config'].restrictions is None else args['oidc_config'].restrictions}"
+                                    ],
+                                ),
+                                GetPolicyDocumentStatementConditionArgs(
+                                    test="StringEquals",
+                                    variable="token.actions.githubusercontent.com:aud",
+                                    values=["sts.amazonaws.com"],
+                                ),
+                            ],
+                        )
+                    ]
+                )
+            )
+            account_name = find_account_name_from_workload_info(
+                workload_info=workload_info, account_id=oidc_config.aws_account_id
+            )
+            _ = iam.Role(
+                f"github-oidc--{account_name}--{oidc_config.role_name}",
+                role_name=oidc_config.role_name,
+                assume_role_policy_document=assume_role_policy_doc.json,
+                managed_policy_arns=oidc_config.managed_policy_arns,
+                tags=common_tags_native(),
+                opts=ResourceOptions(provider=providers[oidc_config.aws_account_id], parent=self),
+            )
+
+
+def deploy_all_oidc(
+    *,
+    all_oidc: list[tuple[AwsLogicalWorkload, list[GithubOidcConfig]]],
+    providers: dict[AwsAccountId, Provider],
+) -> None:
+    for workload_info, oidc_configs in all_oidc:
+        _ = WorkloadGithubOidc(workload_info=workload_info, oidc_configs=oidc_configs, providers=providers)

--- a/src/aws_central_infrastructure/iac_management/github_oidc_lib.py
+++ b/src/aws_central_infrastructure/iac_management/github_oidc_lib.py
@@ -157,6 +157,7 @@ class WorkloadGithubOidc(ComponentResource):
                 role_name=oidc_config.role_name,
                 assume_role_policy_document=assume_role_policy_doc.json,
                 managed_policy_arns=oidc_config.managed_policy_arns,
+                policies=None if oidc_config.role_policy is None else [oidc_config.role_policy],
                 tags=common_tags_native(),
                 opts=ResourceOptions(provider=providers[oidc_config.aws_account_id], parent=self),
             )

--- a/src/aws_central_infrastructure/iac_management/program.py
+++ b/src/aws_central_infrastructure/iac_management/program.py
@@ -1,7 +1,5 @@
 import logging
-from typing import TYPE_CHECKING
 
-import boto3
 from ephemeral_pulumi_deploy import get_aws_account_id
 from ephemeral_pulumi_deploy import get_config
 from ephemeral_pulumi_deploy import get_config_str
@@ -21,15 +19,19 @@ from pulumi_aws_native import s3
 from pulumi_aws_native import ssm
 
 from ..constants import CENTRAL_INFRA_REPO_NAME
-from .shared_lib import WORKLOAD_INFO_SSM_PARAM_PREFIX
+from .github_oidc import generate_all_oidc
+from .github_oidc_lib import AwsAccountId
+from .github_oidc_lib import deploy_all_oidc
 from .shared_lib import AwsLogicalWorkload
+from .workload_params import WorkloadParams
+from .workload_params import load_workload_info
 
-if TYPE_CHECKING:
-    from mypy_boto3_ssm.type_defs import ParameterMetadataTypeDef
 logger = logging.getLogger(__name__)
 
 
 class AwsWorkloadPulumiBootstrap(ComponentResource):
+    providers: dict[AwsAccountId, Provider]
+
     def __init__(
         self,
         *,
@@ -41,6 +43,7 @@ class AwsWorkloadPulumiBootstrap(ComponentResource):
         super().__init__("labauto:AwsWorkloadPulumiBootstrap", workload.name, None)
         all_accounts = [*workload.prod_accounts, *workload.staging_accounts, *workload.dev_accounts]
         run_type = "Preview" if is_dry_run() else "Deploy"
+        self.providers = {}
         for account in all_accounts:
             role_arn = f"arn:aws:iam::{account.id}:role/Infra{run_type}--{CENTRAL_INFRA_REPO_NAME}"
 
@@ -59,6 +62,7 @@ class AwsWorkloadPulumiBootstrap(ComponentResource):
                     ],  # ignore the ARN changes since during a preview we use the Preview Role, not the Deploy Role
                 ),
             )
+            self.providers[account.id] = provider
             _ = ssm.Parameter(
                 f"central-infra-state-bucket-name-in-{account.name}",
                 type=ssm.ParameterType.STRING,
@@ -83,13 +87,13 @@ def create_bucket_policy(bucket_name: str) -> str:
         statements=[
             GetPolicyDocumentStatementArgs(
                 effect="Allow",
+                actions=["s3:PutObject", "s3:GetObject", "s3:DeleteObject"],
                 principals=[
                     GetPolicyDocumentStatementPrincipalArgs(
                         type="*",
                         identifiers=["*"],  # Allows all principals
                     )
                 ],
-                actions=["s3:PutObject", "s3:GetObject", "s3:DeleteObject"],
                 resources=[f"arn:aws:s3:::{bucket_name}/${{aws:PrincipalAccount}}/*"],
                 conditions=[
                     GetPolicyDocumentStatementConditionArgs(
@@ -134,48 +138,23 @@ def pulumi_program() -> None:
         policy_document=create_bucket_policy(central_state_bucket_name),
     )
 
-    ssm_client = boto3.client("ssm", region_name=organization_home_region)
-
-    parameters: list[ParameterMetadataTypeDef] = []
-    next_token = None
-
-    while True:
-        # API call with optional pagination
-        response = ssm_client.describe_parameters(
-            ParameterFilters=[{"Key": "Name", "Option": "BeginsWith", "Values": [WORKLOAD_INFO_SSM_PARAM_PREFIX]}],
-            MaxResults=50,  # AWS allows up to 50 results per call
-            NextToken=next_token if next_token else "",
-        )
-
-        # Add parameters from this page
-        parameters.extend(response.get("Parameters", []))
-
-        # Check if more pages exist
-        next_token = response.get("NextToken")
-        if not next_token:
-            break
-
-    def get_parameter_value(name: str) -> str:
-        response = ssm_client.get_parameter(  # TODO: consider using get_parameters for just a single API call
-            Name=name,
-        )
-        param_dict = response["Parameter"]
-        assert "Value" in param_dict, f"Value not found in parameter {param_dict}"
-        return param_dict["Value"]
-
-    param_values: list[str] = []
-    for param in parameters:
-        assert "Name" in param, f"Name not found in parameter {param}"
-        param_name = param["Name"]
-        param_value = get_parameter_value(param_name)
-        param_values.append(param_value)
-
-    workloads_info = [AwsLogicalWorkload.model_validate_json(param) for param in param_values]
-
-    for workload_info in workloads_info:
-        _ = AwsWorkloadPulumiBootstrap(
+    workloads_dict, params_dict = load_workload_info(organization_home_region=organization_home_region)
+    providers: dict[AwsAccountId, Provider] = {}
+    for workload_info in workloads_dict.values():
+        bootstrap = AwsWorkloadPulumiBootstrap(
             workload=workload_info,
             organization_home_region=organization_home_region,
             central_state_bucket_name=central_state_bucket_name,
             central_iac_kms_key_arn=kmy_key_arn,
         )
+        providers.update(bootstrap.providers)
+    _ = WorkloadParams(
+        name="identity-center",
+        params_dict=params_dict,
+        provider=providers[workloads_dict["identity-center"].prod_accounts[0].id],
+    )
+    all_oidc = generate_all_oidc(workloads_info=workloads_dict, kms_key_arn=kmy_key_arn)
+    deploy_all_oidc(
+        all_oidc=[(workloads_dict[workload_name], value) for workload_name, value in all_oidc.items()],
+        providers=providers,
+    )

--- a/src/aws_central_infrastructure/iac_management/program.py
+++ b/src/aws_central_infrastructure/iac_management/program.py
@@ -64,7 +64,7 @@ class AwsWorkloadPulumiBootstrap(ComponentResource):
                 type=ssm.ParameterType.STRING,
                 name="/org-managed/infra-state-bucket-name",
                 value=central_state_bucket_name,
-                opts=ResourceOptions(provider=provider, parent=self),
+                opts=ResourceOptions(provider=provider, parent=self, delete_before_replace=True),
                 tags=common_tags(),
             )
             _ = ssm.Parameter(
@@ -72,7 +72,7 @@ class AwsWorkloadPulumiBootstrap(ComponentResource):
                 type=ssm.ParameterType.STRING,
                 name="/org-managed/infra-state-kms-key-arn",
                 value=central_iac_kms_key_arn,
-                opts=ResourceOptions(provider=provider, parent=self),
+                opts=ResourceOptions(provider=provider, parent=self, delete_before_replace=True),
                 tags=common_tags(),
             )
 

--- a/src/aws_central_infrastructure/iac_management/program.py
+++ b/src/aws_central_infrastructure/iac_management/program.py
@@ -1,5 +1,6 @@
 import logging
 
+import boto3
 from ephemeral_pulumi_deploy import get_aws_account_id
 from ephemeral_pulumi_deploy import get_config
 from ephemeral_pulumi_deploy import get_config_str
@@ -10,6 +11,9 @@ from pulumi_aws.iam import GetPolicyDocumentStatementPrincipalArgs
 from pulumi_aws.iam import get_policy_document
 from pulumi_aws.organizations import get_organization
 from pulumi_aws_native import s3
+
+from .shared_lib import WORKLOAD_INFO_SSM_PARAM_PREFIX
+from .shared_lib import AwsLogicalWorkload
 
 logger = logging.getLogger(__name__)
 
@@ -62,10 +66,61 @@ def pulumi_program() -> None:
     export("env", env)
 
     # Create Resources Here
-
+    organization_home_region = "us-east-1"
     central_state_bucket_name = get_config_str("proj:backend_bucket_name")
     _ = s3.BucketPolicy(
         "bucket-policy",
         bucket=central_state_bucket_name,
         policy_document=create_bucket_policy(central_state_bucket_name),
     )
+
+    ssm_client = boto3.client("ssm", region_name=organization_home_region)
+
+    parameters = []
+    next_token = None
+
+    while True:
+        # API call with optional pagination
+        response = ssm_client.describe_parameters(
+            ParameterFilters=[{"Key": "Name", "Option": "BeginsWith", "Values": [WORKLOAD_INFO_SSM_PARAM_PREFIX]}],
+            MaxResults=50,  # AWS allows up to 50 results per call
+            NextToken=next_token if next_token else "",
+        )
+
+        # Add parameters from this page
+        parameters.extend(response.get("Parameters", []))
+
+        # Check if more pages exist
+        next_token = response.get("NextToken")
+        if not next_token:
+            break
+
+    def get_parameter_value(name: str) -> str:
+        response = ssm_client.get_parameter(
+            Name=name,
+        )
+        return response["Parameter"]["Value"]
+
+    param_values: list[str] = []
+    for param in parameters:
+        param_name = param["Name"]
+        param_value = get_parameter_value(param_name)
+        param_values.append(param_value)
+
+    workloads_info = [AwsLogicalWorkload.model_validate_json(param) for param in param_values]
+
+    # for workload_info in workloads_info:
+    #     all_accounts = [*workload_info.prod_accounts, *workload_info.staging_accounts, *workload_info.dev_accounts]
+    #     for account in all_accounts:
+    #         deploy_role_arn = f"arn:aws:iam::{account.id}:role/InfraDeploy--{CENTRAL_INFRA_REPO_NAME}"
+
+    #         assume_role = ProviderAssumeRoleArgs(role_arn=central_infra_role_arn, session_name="pulumi")
+    #         central_infra_provider = Provider(
+    #             f"{central_infra_account_name}",
+    #             assume_role=assume_role,
+    #             allowed_account_ids=[central_infra_account.account.id],
+    #             region="us-east-1",
+    #             opts=ResourceOptions(
+    #                 parent=central_infra_account,
+    #             ),
+    #         )

--- a/src/aws_central_infrastructure/iac_management/program.py
+++ b/src/aws_central_infrastructure/iac_management/program.py
@@ -68,7 +68,7 @@ class AwsWorkloadPulumiBootstrap(ComponentResource):
                 tags=common_tags(),
             )
             _ = ssm.Parameter(
-                "shared-kms-key-arn-in-{account.name}",
+                f"shared-kms-key-arn-in-{account.name}",
                 type=ssm.ParameterType.STRING,
                 name="/org-managed/infra-state-kms-key-arn",
                 value=central_iac_kms_key_arn,

--- a/src/aws_central_infrastructure/iac_management/program.py
+++ b/src/aws_central_infrastructure/iac_management/program.py
@@ -141,6 +141,8 @@ def pulumi_program() -> None:
     workloads_dict, params_dict = load_workload_info(organization_home_region=organization_home_region)
     providers: dict[AwsAccountId, Provider] = {}
     for workload_info in workloads_dict.values():
+        if workload_info.name == "central-infra":
+            continue  # don't bootstrap the Central Infra 'workload'---it's unique and has been bootstrapped already by the AWS Organization stack
         bootstrap = AwsWorkloadPulumiBootstrap(
             workload=workload_info,
             organization_home_region=organization_home_region,

--- a/src/aws_central_infrastructure/iac_management/program.py
+++ b/src/aws_central_infrastructure/iac_management/program.py
@@ -1,21 +1,80 @@
 import logging
+from typing import TYPE_CHECKING
 
 import boto3
 from ephemeral_pulumi_deploy import get_aws_account_id
 from ephemeral_pulumi_deploy import get_config
 from ephemeral_pulumi_deploy import get_config_str
+from ephemeral_pulumi_deploy.utils import common_tags
+from pulumi import ComponentResource
+from pulumi import ResourceOptions
 from pulumi import export
+from pulumi.runtime import is_dry_run
 from pulumi_aws.iam import GetPolicyDocumentStatementArgs
 from pulumi_aws.iam import GetPolicyDocumentStatementConditionArgs
 from pulumi_aws.iam import GetPolicyDocumentStatementPrincipalArgs
 from pulumi_aws.iam import get_policy_document
 from pulumi_aws.organizations import get_organization
+from pulumi_aws_native import Provider
+from pulumi_aws_native import ProviderAssumeRoleArgs
 from pulumi_aws_native import s3
+from pulumi_aws_native import ssm
 
+from ..constants import CENTRAL_INFRA_REPO_NAME
 from .shared_lib import WORKLOAD_INFO_SSM_PARAM_PREFIX
 from .shared_lib import AwsLogicalWorkload
 
+if TYPE_CHECKING:
+    from mypy_boto3_ssm.type_defs import ParameterMetadataTypeDef
 logger = logging.getLogger(__name__)
+
+
+class AwsWorkloadPulumiBootstrap(ComponentResource):
+    def __init__(
+        self,
+        *,
+        workload: AwsLogicalWorkload,
+        organization_home_region: str,
+        central_state_bucket_name: str,
+        central_iac_kms_key_arn: str,
+    ):
+        super().__init__("labauto:AwsWorkloadPulumiBootstrap", workload.name, None)
+        all_accounts = [*workload.prod_accounts, *workload.staging_accounts, *workload.dev_accounts]
+        run_type = "Preview" if is_dry_run() else "Deploy"
+        for account in all_accounts:
+            role_arn = f"arn:aws:iam::{account.id}:role/Infra{run_type}--{CENTRAL_INFRA_REPO_NAME}"
+
+            assume_role = ProviderAssumeRoleArgs(role_arn=role_arn, session_name=f"pulumi-{run_type.lower()}")
+            provider = Provider(
+                f"central-infra-provider-for-{account.name}",
+                assume_role=assume_role,
+                allowed_account_ids=[account.id],
+                region=organization_home_region,
+                opts=ResourceOptions(
+                    parent=self,
+                    # TODO: figure out why ignore_changes isn't working
+                    ignore_changes=[
+                        "assumeRole.roleArn",
+                        "assumeRole.sessionName",
+                    ],  # ignore the ARN changes since during a preview we use the Preview Role, not the Deploy Role
+                ),
+            )
+            _ = ssm.Parameter(
+                f"central-infra-state-bucket-name-in-{account.name}",
+                type=ssm.ParameterType.STRING,
+                name="/org-managed/infra-state-bucket-name",
+                value=central_state_bucket_name,
+                opts=ResourceOptions(provider=provider, parent=self),
+                tags=common_tags(),
+            )
+            _ = ssm.Parameter(
+                "shared-kms-key-arn-in-{account.name}",
+                type=ssm.ParameterType.STRING,
+                name="/org-managed/infra-state-kms-key-arn",
+                value=central_iac_kms_key_arn,
+                opts=ResourceOptions(provider=provider, parent=self),
+                tags=common_tags(),
+            )
 
 
 def create_bucket_policy(bucket_name: str) -> str:
@@ -68,6 +127,7 @@ def pulumi_program() -> None:
     # Create Resources Here
     organization_home_region = "us-east-1"
     central_state_bucket_name = get_config_str("proj:backend_bucket_name")
+    kmy_key_arn = get_config_str("proj:kms_key_id")
     _ = s3.BucketPolicy(
         "bucket-policy",
         bucket=central_state_bucket_name,
@@ -76,7 +136,7 @@ def pulumi_program() -> None:
 
     ssm_client = boto3.client("ssm", region_name=organization_home_region)
 
-    parameters = []
+    parameters: list[ParameterMetadataTypeDef] = []
     next_token = None
 
     while True:
@@ -96,31 +156,26 @@ def pulumi_program() -> None:
             break
 
     def get_parameter_value(name: str) -> str:
-        response = ssm_client.get_parameter(
+        response = ssm_client.get_parameter(  # TODO: consider using get_parameters for just a single API call
             Name=name,
         )
-        return response["Parameter"]["Value"]
+        param_dict = response["Parameter"]
+        assert "Value" in param_dict, f"Value not found in parameter {param_dict}"
+        return param_dict["Value"]
 
     param_values: list[str] = []
     for param in parameters:
+        assert "Name" in param, f"Name not found in parameter {param}"
         param_name = param["Name"]
         param_value = get_parameter_value(param_name)
         param_values.append(param_value)
 
     workloads_info = [AwsLogicalWorkload.model_validate_json(param) for param in param_values]
 
-    # for workload_info in workloads_info:
-    #     all_accounts = [*workload_info.prod_accounts, *workload_info.staging_accounts, *workload_info.dev_accounts]
-    #     for account in all_accounts:
-    #         deploy_role_arn = f"arn:aws:iam::{account.id}:role/InfraDeploy--{CENTRAL_INFRA_REPO_NAME}"
-
-    #         assume_role = ProviderAssumeRoleArgs(role_arn=central_infra_role_arn, session_name="pulumi")
-    #         central_infra_provider = Provider(
-    #             f"{central_infra_account_name}",
-    #             assume_role=assume_role,
-    #             allowed_account_ids=[central_infra_account.account.id],
-    #             region="us-east-1",
-    #             opts=ResourceOptions(
-    #                 parent=central_infra_account,
-    #             ),
-    #         )
+    for workload_info in workloads_info:
+        _ = AwsWorkloadPulumiBootstrap(
+            workload=workload_info,
+            organization_home_region=organization_home_region,
+            central_state_bucket_name=central_state_bucket_name,
+            central_iac_kms_key_arn=kmy_key_arn,
+        )

--- a/src/aws_central_infrastructure/iac_management/shared_lib.py
+++ b/src/aws_central_infrastructure/iac_management/shared_lib.py
@@ -1,0 +1,26 @@
+"""Information in here is shared between the AWS Organization repo and the Central Infrastructure repo."""
+
+from pydantic import BaseModel
+from pydantic import Field
+
+WORKLOAD_INFO_SSM_PARAM_PREFIX = "/org-managed/logical-workloads"
+
+
+class AwsAccountInfo(BaseModel, frozen=True):
+    version: str = "0.0.1"
+    id: str
+    name: str
+
+
+class AwsLogicalWorkload(BaseModel):
+    version: str = "0.0.1"
+    name: str
+    prod_accounts: list[AwsAccountInfo] = Field(
+        default_factory=list
+    )  # TODO: convert to a set with deterministic ordering to avoid false positive diffs
+    staging_accounts: list[AwsAccountInfo] = Field(
+        default_factory=list
+    )  # TODO: convert to a set with deterministic ordering to avoid false positive diffs
+    dev_accounts: list[AwsAccountInfo] = Field(
+        default_factory=list
+    )  # TODO: convert to a set with deterministic ordering to avoid false positive diffs

--- a/src/aws_central_infrastructure/iac_management/workload_params.py
+++ b/src/aws_central_infrastructure/iac_management/workload_params.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 import boto3
+from ephemeral_pulumi_deploy import get_config_str
 from ephemeral_pulumi_deploy.utils import common_tags
 from pulumi import ComponentResource
 from pulumi import ResourceOptions
@@ -38,10 +39,8 @@ class WorkloadParams(ComponentResource):
             )
 
 
-def load_workload_info(
-    *, organization_home_region: str
-) -> tuple[dict[WorkloadName, AwsLogicalWorkload], dict[str, str]]:
-    ssm_client = boto3.client("ssm", region_name=organization_home_region)
+def load_workload_info() -> tuple[dict[WorkloadName, AwsLogicalWorkload], dict[str, str]]:
+    ssm_client = boto3.client("ssm", region_name=get_config_str("proj:aws_org_home_region"))
 
     parameters: list[ParameterMetadataTypeDef] = []
     next_token = None

--- a/src/aws_central_infrastructure/iac_management/workload_params.py
+++ b/src/aws_central_infrastructure/iac_management/workload_params.py
@@ -1,0 +1,84 @@
+from typing import TYPE_CHECKING
+
+import boto3
+from ephemeral_pulumi_deploy.utils import common_tags
+from pulumi import ComponentResource
+from pulumi import ResourceOptions
+from pulumi_aws_native import Provider
+from pulumi_aws_native import ssm
+
+from .github_oidc_lib import WorkloadName
+from .shared_lib import WORKLOAD_INFO_SSM_PARAM_PREFIX
+from .shared_lib import AwsLogicalWorkload
+
+if TYPE_CHECKING:
+    from mypy_boto3_ssm.type_defs import ParameterMetadataTypeDef
+
+
+class WorkloadParams(ComponentResource):
+    def __init__(
+        self,
+        *,
+        name: str,
+        params_dict: dict[str, str],
+        provider: Provider,
+    ):
+        super().__init__("labauto:AwsWorkloadParams", name, None)
+        # replicate the workload information into the Identity Center account
+        for param_name, param_value in params_dict.items():
+            workload_name = param_name.split("/")[-1]
+            _ = ssm.Parameter(
+                f"{workload_name}-workload-info-for-{name}",
+                type=ssm.ParameterType.STRING,
+                name=param_name,
+                description=f"Hold the logical workload information for {workload_name} so that {name} account can access it for easy reference.",
+                tags=common_tags(),
+                value=param_value,
+                opts=ResourceOptions(provider=provider, parent=self, delete_before_replace=True),
+            )
+
+
+def load_workload_info(
+    *, organization_home_region: str
+) -> tuple[dict[WorkloadName, AwsLogicalWorkload], dict[str, str]]:
+    ssm_client = boto3.client("ssm", region_name=organization_home_region)
+
+    parameters: list[ParameterMetadataTypeDef] = []
+    next_token = None
+
+    while True:
+        # API call with optional pagination
+        response = ssm_client.describe_parameters(
+            ParameterFilters=[{"Key": "Name", "Option": "BeginsWith", "Values": [WORKLOAD_INFO_SSM_PARAM_PREFIX]}],
+            MaxResults=50,  # AWS allows up to 50 results per call
+            NextToken=next_token if next_token else "",
+        )
+
+        # Add parameters from this page
+        parameters.extend(response.get("Parameters", []))
+
+        # Check if more pages exist
+        next_token = response.get("NextToken")
+        if not next_token:
+            break
+
+    def get_parameter_value(name: str) -> str:
+        response = ssm_client.get_parameter(  # TODO: consider using get_parameters for just a single API call
+            Name=name,
+        )
+        param_dict = response["Parameter"]
+        assert "Value" in param_dict, f"Value not found in parameter {param_dict}"
+        return param_dict["Value"]
+
+    param_values: list[str] = []
+    params_dict: dict[str, str] = {}
+    for param in parameters:
+        assert "Name" in param, f"Name not found in parameter {param}"
+        param_name = param["Name"]
+        param_value = get_parameter_value(param_name)
+        param_values.append(param_value)
+        params_dict[param_name] = param_value
+
+    workloads_info = [AwsLogicalWorkload.model_validate_json(param) for param in param_values]
+    workloads_dict: dict[WorkloadName, AwsLogicalWorkload] = {workload.name: workload for workload in workloads_info}
+    return workloads_dict, params_dict

--- a/src/aws_central_infrastructure/identity_center/lib.py
+++ b/src/aws_central_infrastructure/identity_center/lib.py
@@ -1,0 +1,85 @@
+from pulumi import ComponentResource
+from pulumi import ResourceOptions
+from pulumi_aws import identitystore as identitystore_classic
+from pulumi_aws import ssoadmin
+
+
+class AwsSsoPermissionSet(ComponentResource):
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        managed_policies: list[str],
+    ):
+        super().__init__("labauto:AwsSsoPermissionSet", name, None)
+        sso_instances = ssoadmin.get_instances()
+        assert len(sso_instances.arns) == 1, "Expected a single AWS SSO instance to exist"
+        sso_instance_arn = sso_instances.arns[0]
+        self.name = name
+        permission_set = ssoadmin.PermissionSet(
+            name,
+            instance_arn=sso_instance_arn,
+            name=name,
+            description=description,
+            session_duration="PT12H",
+            opts=ResourceOptions(parent=self),
+        )
+        self.permission_set_arn = permission_set.arn
+        for policy_name in managed_policies:
+            _ = ssoadmin.ManagedPolicyAttachment(
+                f"{name}-{policy_name}",
+                instance_arn=sso_instance_arn,
+                managed_policy_arn=f"arn:aws:iam::aws:policy/{policy_name}",
+                permission_set_arn=self.permission_set_arn,
+                opts=ResourceOptions(parent=self),
+            )
+        self.register_outputs(
+            {
+                "permission_set_arn": self.permission_set_arn,
+            }
+        )
+
+
+class AwsSsoPermissionSetAccountAssignments(ComponentResource):
+    def __init__(
+        self,
+        *,
+        account_id: str,
+        account_name: str,
+        permission_set: AwsSsoPermissionSet,
+        users: list[str],
+    ):
+        resource_name = f"{permission_set.name}-{account_name}"
+        super().__init__(
+            "labauto:AwsSsoPermissionSetAccountAssignments",
+            resource_name,
+            None,
+        )
+        sso_instances = ssoadmin.get_instances()
+        assert len(sso_instances.arns) == 1, "Expected a single AWS SSO instance to exist"
+        sso_instance_arn = sso_instances.arns[0]
+        self.identity_store_id = sso_instances.identity_store_ids[0]
+        users = list(set(users))  # Remove any duplicates in the list
+
+        for user in users:
+            _ = ssoadmin.AccountAssignment(
+                f"{resource_name}-{user}",
+                instance_arn=sso_instance_arn,
+                permission_set_arn=permission_set.permission_set_arn,
+                principal_id=self.lookup_user_id(user),
+                principal_type="USER",
+                target_id=account_id,
+                target_type="AWS_ACCOUNT",
+                opts=ResourceOptions(parent=self),
+            )
+
+    def lookup_user_id(self, name: str) -> str:
+        """Convert a username <first>.<last> name into an AWS SSO User ID."""
+        return identitystore_classic.get_user(
+            alternate_identifier=identitystore_classic.GetUserAlternateIdentifierArgs(
+                unique_attribute=identitystore_classic.GetUserAlternateIdentifierUniqueAttributeArgs(
+                    attribute_path="UserName", attribute_value=name
+                )
+            ),
+            identity_store_id=self.identity_store_id,
+        ).user_id

--- a/src/aws_central_infrastructure/identity_center/lib.py
+++ b/src/aws_central_infrastructure/identity_center/lib.py
@@ -3,10 +3,13 @@ from pulumi import ResourceOptions
 from pulumi_aws import identitystore as identitystore_classic
 from pulumi_aws import ssoadmin
 
+from ..iac_management.shared_lib import AwsAccountInfo
+
 
 class AwsSsoPermissionSet(ComponentResource):
     def __init__(
         self,
+        *,
         name: str,
         description: str,
         managed_policies: list[str],
@@ -44,12 +47,11 @@ class AwsSsoPermissionSetAccountAssignments(ComponentResource):
     def __init__(
         self,
         *,
-        account_id: str,
-        account_name: str,
+        account_info: AwsAccountInfo,
         permission_set: AwsSsoPermissionSet,
         users: list[str],
     ):
-        resource_name = f"{permission_set.name}-{account_name}"
+        resource_name = f"{permission_set.name}-{account_info.name}"
         super().__init__(
             "labauto:AwsSsoPermissionSetAccountAssignments",
             resource_name,
@@ -68,7 +70,7 @@ class AwsSsoPermissionSetAccountAssignments(ComponentResource):
                 permission_set_arn=permission_set.permission_set_arn,
                 principal_id=self.lookup_user_id(user),
                 principal_type="USER",
-                target_id=account_id,
+                target_id=account_info.id,
                 target_type="AWS_ACCOUNT",
                 opts=ResourceOptions(parent=self),
             )

--- a/src/aws_central_infrastructure/identity_center/permissions.py
+++ b/src/aws_central_infrastructure/identity_center/permissions.py
@@ -5,7 +5,7 @@ from .lib import AwsSsoPermissionSetAccountAssignments
 
 def create_permissions(workloads_dict: dict[str, AwsLogicalWorkload]) -> None:
     admin_permission_set = AwsSsoPermissionSet(
-        name="LowRiskAccountAdminAccess2",
+        name="LowRiskAccountAdminAccess",
         description="Low Risk Account Admin Access",
         managed_policies=["AdministratorAccess"],
     )

--- a/src/aws_central_infrastructure/identity_center/permissions.py
+++ b/src/aws_central_infrastructure/identity_center/permissions.py
@@ -1,0 +1,27 @@
+from ..iac_management.shared_lib import AwsLogicalWorkload
+from .lib import AwsSsoPermissionSet
+from .lib import AwsSsoPermissionSetAccountAssignments
+
+
+def create_permissions(workloads_dict: dict[str, AwsLogicalWorkload]) -> None:
+    admin_permission_set = AwsSsoPermissionSet(
+        name="LowRiskAccountAdminAccess2",
+        description="Low Risk Account Admin Access",
+        managed_policies=["AdministratorAccess"],
+    )
+
+    _ = AwsSsoPermissionSetAccountAssignments(
+        account_info=workloads_dict["central-infra"].prod_accounts[0],
+        permission_set=admin_permission_set,
+        users=["eli.fine"],
+    )
+    _ = AwsSsoPermissionSetAccountAssignments(
+        account_info=workloads_dict["biotasker"].dev_accounts[0],
+        permission_set=admin_permission_set,
+        users=["eli.fine"],
+    )
+    _ = AwsSsoPermissionSetAccountAssignments(
+        account_info=workloads_dict["identity-center"].prod_accounts[0],
+        permission_set=admin_permission_set,
+        users=["eli.fine"],
+    )

--- a/src/aws_central_infrastructure/identity_center/program.py
+++ b/src/aws_central_infrastructure/identity_center/program.py
@@ -1,0 +1,22 @@
+import logging
+
+from ephemeral_pulumi_deploy import get_aws_account_id
+from ephemeral_pulumi_deploy import get_config
+from pulumi import export
+
+from ..iac_management.workload_params import load_workload_info
+
+logger = logging.getLogger(__name__)
+
+
+def pulumi_program() -> None:
+    """Execute creating the stack."""
+    env = get_config("proj:env")
+    export("env", env)
+    aws_account_id = get_aws_account_id()
+    export("aws-account-id", aws_account_id)
+
+    # Create Resources Here
+    organization_home_region = "us-east-1"
+    workloads_dict, _ = load_workload_info(organization_home_region=organization_home_region)
+    del workloads_dict

--- a/src/aws_central_infrastructure/identity_center/program.py
+++ b/src/aws_central_infrastructure/identity_center/program.py
@@ -5,6 +5,7 @@ from ephemeral_pulumi_deploy import get_config
 from pulumi import export
 
 from ..iac_management.workload_params import load_workload_info
+from .permissions import create_permissions
 
 logger = logging.getLogger(__name__)
 
@@ -19,4 +20,4 @@ def pulumi_program() -> None:
     # Create Resources Here
     organization_home_region = "us-east-1"
     workloads_dict, _ = load_workload_info(organization_home_region=organization_home_region)
-    del workloads_dict
+    create_permissions(workloads_dict)

--- a/src/aws_central_infrastructure/identity_center/program.py
+++ b/src/aws_central_infrastructure/identity_center/program.py
@@ -18,6 +18,5 @@ def pulumi_program() -> None:
     export("aws-account-id", aws_account_id)
 
     # Create Resources Here
-    organization_home_region = "us-east-1"
-    workloads_dict, _ = load_workload_info(organization_home_region=organization_home_region)
+    workloads_dict, _ = load_workload_info()
     create_permissions(workloads_dict)

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,15 @@ version = 1
 requires-python = ">=3.13.1"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643 },
+]
+
+[[package]]
 name = "arpeggio"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -31,6 +40,7 @@ dependencies = [
     { name = "pulumi-aws" },
     { name = "pulumi-aws-native" },
     { name = "pulumi-command" },
+    { name = "pydantic" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -46,6 +56,7 @@ requires-dist = [
     { name = "pulumi-aws", specifier = ">=6.66.3" },
     { name = "pulumi-aws-native", specifier = ">=1.24.0" },
     { name = "pulumi-command", specifier = ">=1.0.1" },
+    { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pyright", specifier = ">=1.1.393" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
@@ -4369,6 +4380,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dd/c0/a6304d7697a22cec1f71101613eb81fe5f98549c36040d40a5d0a9cc759e/pulumi_command-1.0.1.tar.gz", hash = "sha256:58e123707956aa7a9be2ce89c009642539cde5d9fa02e1e10501662600894843", size = 31532 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/f1/a7616bc13081a110d8c2d0fe26c42249735154fa2732c86fab9ef8de0844/pulumi_command-1.0.1-py3-none-any.whl", hash = "sha256:672cdea9c0ced0f79ed47e578267a2b2160dcf88626dde34ee96f5524a003574", size = 34742 },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.10.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/ae/d5220c5c52b158b1de7ca89fc5edb72f304a70a4c540c84c8844bf4008de/pydantic-2.10.6.tar.gz", hash = "sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236", size = 761681 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/3c/8cc1cc84deffa6e25d2d0c688ebb80635dfdbf1dbea3e30c541c8cf4d860/pydantic-2.10.6-py3-none-any.whl", hash = "sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584", size = 431696 },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/01/f3e5ac5e7c25833db5eb555f7b7ab24cd6f8c322d3a3ad2d67a952dc0abc/pydantic_core-2.27.2.tar.gz", hash = "sha256:eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39", size = 413443 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/b1/9bc383f48f8002f99104e3acff6cba1231b29ef76cfa45d1506a5cad1f84/pydantic_core-2.27.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7d14bd329640e63852364c306f4d23eb744e0f8193148d4044dd3dacdaacbd8b", size = 1892709 },
+    { url = "https://files.pythonhosted.org/packages/10/6c/e62b8657b834f3eb2961b49ec8e301eb99946245e70bf42c8817350cbefc/pydantic_core-2.27.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82f91663004eb8ed30ff478d77c4d1179b3563df6cdb15c0817cd1cdaf34d154", size = 1811273 },
+    { url = "https://files.pythonhosted.org/packages/ba/15/52cfe49c8c986e081b863b102d6b859d9defc63446b642ccbbb3742bf371/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71b24c7d61131bb83df10cc7e687433609963a944ccf45190cfc21e0887b08c9", size = 1823027 },
+    { url = "https://files.pythonhosted.org/packages/b1/1c/b6f402cfc18ec0024120602bdbcebc7bdd5b856528c013bd4d13865ca473/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9", size = 1868888 },
+    { url = "https://files.pythonhosted.org/packages/bd/7b/8cb75b66ac37bc2975a3b7de99f3c6f355fcc4d89820b61dffa8f1e81677/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce8918cbebc8da707ba805b7fd0b382816858728ae7fe19a942080c24e5b7cd1", size = 2037738 },
+    { url = "https://files.pythonhosted.org/packages/c8/f1/786d8fe78970a06f61df22cba58e365ce304bf9b9f46cc71c8c424e0c334/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3f5c2a021bbc5d976107bb302e0131351c2ba54343f8a496dc8783d3d3a6a", size = 2685138 },
+    { url = "https://files.pythonhosted.org/packages/a6/74/d12b2cd841d8724dc8ffb13fc5cef86566a53ed358103150209ecd5d1999/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8086fa684c4775c27f03f062cbb9eaa6e17f064307e86b21b9e0abc9c0f02e", size = 1997025 },
+    { url = "https://files.pythonhosted.org/packages/a0/6e/940bcd631bc4d9a06c9539b51f070b66e8f370ed0933f392db6ff350d873/pydantic_core-2.27.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8d9b3388db186ba0c099a6d20f0604a44eabdeef1777ddd94786cdae158729e4", size = 2004633 },
+    { url = "https://files.pythonhosted.org/packages/50/cc/a46b34f1708d82498c227d5d80ce615b2dd502ddcfd8376fc14a36655af1/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7a66efda2387de898c8f38c0cf7f14fca0b51a8ef0b24bfea5849f1b3c95af27", size = 1999404 },
+    { url = "https://files.pythonhosted.org/packages/ca/2d/c365cfa930ed23bc58c41463bae347d1005537dc8db79e998af8ba28d35e/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:18a101c168e4e092ab40dbc2503bdc0f62010e95d292b27827871dc85450d7ee", size = 2130130 },
+    { url = "https://files.pythonhosted.org/packages/f4/d7/eb64d015c350b7cdb371145b54d96c919d4db516817f31cd1c650cae3b21/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ba5dd002f88b78a4215ed2f8ddbdf85e8513382820ba15ad5ad8955ce0ca19a1", size = 2157946 },
+    { url = "https://files.pythonhosted.org/packages/a4/99/bddde3ddde76c03b65dfd5a66ab436c4e58ffc42927d4ff1198ffbf96f5f/pydantic_core-2.27.2-cp313-cp313-win32.whl", hash = "sha256:1ebaf1d0481914d004a573394f4be3a7616334be70261007e47c2a6fe7e50130", size = 1834387 },
+    { url = "https://files.pythonhosted.org/packages/71/47/82b5e846e01b26ac6f1893d3c5f9f3a2eb6ba79be26eef0b759b4fe72946/pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee", size = 1990453 },
+    { url = "https://files.pythonhosted.org/packages/51/b2/b2b50d5ecf21acf870190ae5d093602d95f66c9c31f9d5de6062eb329ad1/pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b", size = 1885186 },
 ]
 
 [[package]]


### PR DESCRIPTION
 ## Why is this change necessary?
Need to be able to deploy OIDC Providers and Roles in subaccounts. Need to be able to manage permission sets and account assignments.


 ## How does this change address the issue?
Adds ability to configure an OIDC Provider and Role within a workload. Does this for the Identity Center workload.

Adds the Identity Center stack to manage Permission Sets


 ## What side effects does this change have?
None


 ## How is this change tested?
Some live deploys

