### PR TITLE
Instantiate User

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.1-3-g8a76abe
+_commit: v0.0.1-4-g0d9474d
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_org_home_region: us-east-1

--- a/src/aws_central_infrastructure/identity_center/lib.py
+++ b/src/aws_central_infrastructure/identity_center/lib.py
@@ -111,10 +111,11 @@ class User(BaseModel):  # NOT RECOMMENDED TO USE THIS IF YOU HAVE AN EXTERNAL ID
     first_name: str
     last_name: str
     email: str
+    _user: identitystore_classic.User | None = None
 
     @override
     def model_post_init(self, _: Any) -> None:
-        _ = identitystore_classic.User(
+        self._user = identitystore_classic.User(
             f"{self.first_name}-{self.last_name}",
             identity_store_id=ORG_INFO.identity_store_id,
             display_name=f"{self.first_name} {self.last_name}",
@@ -125,3 +126,8 @@ class User(BaseModel):  # NOT RECOMMENDED TO USE THIS IF YOU HAVE AN EXTERNAL ID
             ),
             emails=identitystore_classic.UserEmailsArgs(primary=True, value=self.email),
         )
+
+    @property
+    def user(self) -> identitystore_classic.User:
+        assert self._user is not None
+        return self._user

--- a/src/aws_central_infrastructure/identity_center/permissions.py
+++ b/src/aws_central_infrastructure/identity_center/permissions.py
@@ -1,27 +1,10 @@
 from ..iac_management.shared_lib import AwsLogicalWorkload
 from .lib import AwsSsoPermissionSet
-from .lib import AwsSsoPermissionSetAccountAssignments
 
 
-def create_permissions(workloads_dict: dict[str, AwsLogicalWorkload]) -> None:
-    admin_permission_set = AwsSsoPermissionSet(
+def create_permissions(workloads_dict: dict[str, AwsLogicalWorkload]) -> None:  # noqa: ARG001 # this argument will be used when the template is instantiated
+    _ = AwsSsoPermissionSet(
         name="LowRiskAccountAdminAccess",
         description="Low Risk Account Admin Access",
         managed_policies=["AdministratorAccess"],
-    )
-
-    _ = AwsSsoPermissionSetAccountAssignments(
-        account_info=workloads_dict["central-infra"].prod_accounts[0],
-        permission_set=admin_permission_set,
-        users=["eli.fine"],
-    )
-    _ = AwsSsoPermissionSetAccountAssignments(
-        account_info=workloads_dict["biotasker"].dev_accounts[0],
-        permission_set=admin_permission_set,
-        users=["eli.fine"],
-    )
-    _ = AwsSsoPermissionSetAccountAssignments(
-        account_info=workloads_dict["identity-center"].prod_accounts[0],
-        permission_set=admin_permission_set,
-        users=["eli.fine"],
     )

--- a/src/aws_central_infrastructure/identity_center/program.py
+++ b/src/aws_central_infrastructure/identity_center/program.py
@@ -20,5 +20,6 @@ def pulumi_program() -> None:
 
     # Create Resources Here
     workloads_dict, _ = load_workload_info()
+    # Note: you must create any new users and deploy them before you can assign any permissions to them (otherwise the Preview will fail)
     create_users()
     create_permissions(workloads_dict)


### PR DESCRIPTION
 ## Why is this change necessary?
Users have to be created before they can be assigned to permission sets


 ## How does this change address the issue?
Deletes the permission set assignments for now and just creates the new user


 ## What side effects does this change have?
Assignments gone temporarily


 ## How is this change tested?
N/A



