### PR TITLE
Reenable permission set assignments

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.1-4-g0d9474d
+_commit: v0.0.2
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_org_home_region: us-east-1

--- a/src/aws_central_infrastructure/identity_center/permissions.py
+++ b/src/aws_central_infrastructure/identity_center/permissions.py
@@ -1,10 +1,27 @@
 from ..iac_management.shared_lib import AwsLogicalWorkload
 from .lib import AwsSsoPermissionSet
+from .lib import AwsSsoPermissionSetAccountAssignments
 
 
-def create_permissions(workloads_dict: dict[str, AwsLogicalWorkload]) -> None:  # noqa: ARG001 # this argument will be used when the template is instantiated
-    _ = AwsSsoPermissionSet(
+def create_permissions(workloads_dict: dict[str, AwsLogicalWorkload]) -> None:
+    admin_permission_set = AwsSsoPermissionSet(
         name="LowRiskAccountAdminAccess",
         description="Low Risk Account Admin Access",
         managed_policies=["AdministratorAccess"],
+    )
+
+    _ = AwsSsoPermissionSetAccountAssignments(
+        account_info=workloads_dict["central-infra"].prod_accounts[0],
+        permission_set=admin_permission_set,
+        users=["eli.fine"],
+    )
+    _ = AwsSsoPermissionSetAccountAssignments(
+        account_info=workloads_dict["biotasker"].dev_accounts[0],
+        permission_set=admin_permission_set,
+        users=["eli.fine"],
+    )
+    _ = AwsSsoPermissionSetAccountAssignments(
+        account_info=workloads_dict["identity-center"].prod_accounts[0],
+        permission_set=admin_permission_set,
+        users=["eli.fine"],
     )


### PR DESCRIPTION
 ## Why is this change necessary?
They had to be removed while the user was transitioned from a manual user to one created via IaC


 ## How does this change address the issue?
Adds them back


 ## What side effects does this change have?
None


 ## How is this change tested?
Preview

