### PR TITLE
SSM Artifact Buckets

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.3-6-g4a8d25f
+_commit: v0.0.3-8-g0249b9f
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_org_home_region: us-east-1

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.3-5-g5816a7c
+_commit: v0.0.3-6-g4a8d25f
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_org_home_region: us-east-1

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.3
+_commit: v0.0.3-5-g5816a7c
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_org_home_region: us-east-1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,21 @@ jobs:
       PULUMI_UP_ROLE_NAME: InfraDeploy--aws-central-infrastructure
       AWS_ACCOUNT_ID: "038462771856"
 
+  artifact-stores-pulumi:
+    uses: ./.github/workflows/pulumi-aws.yml
+    needs: [ iac-management-pulumi ]
+    with:
+      AWS_REGION: us-east-1
+      PULUMI_STACK_NAME: prod
+      PYTHON_VERSION: 3.13.1
+      DEPLOY_SCRIPT_MODULE_NAME: aws_central_infrastructure
+      DEPLOY_SCRIPT_NAME: deploy_artifact_stores
+      PULUMI_PREVIEW: true
+      PREVIEW_ROLE_NAME: InfraPreview--aws-central-infrastructure
+      PULUMI_UP: ${{ github.ref == 'refs/heads/main' }}
+      PULUMI_UP_ROLE_NAME: InfraDeploy--aws-central-infrastructure
+      AWS_ACCOUNT_ID: "038462771856"
+
   identity-center-pulumi:
     uses: ./.github/workflows/pulumi-aws.yml
     needs: [ iac-management-pulumi ]
@@ -79,10 +94,10 @@ jobs:
 
   required-check:
     runs-on: ubuntu-24.04
-    needs: [ lint, iac-management-pulumi, identity-center-pulumi ]
+    needs: [ lint, iac-management-pulumi, artifact-stores-pulumi, identity-center-pulumi ]
     if: always()
     steps:
       - name: fail if prior job failure
-        if: needs.lint.result != 'success' || needs.iac-management-pulumi.result != 'success' || needs.identity-center-pulumi.result != 'success'
+        if: needs.lint.result != 'success' || needs.iac-management-pulumi.result != 'success' || needs.artifact-stores-pulumi.result != 'success' || needs.identity-center-pulumi.result != 'success'
         run: |
           exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
 
   identity-center-pulumi:
     uses: ./.github/workflows/pulumi-aws.yml
-    needs: [ iac-management-pulumi ]
+    needs: [ iac-management-pulumi, artifact-stores-pulumi ] # Identity Center depends on outputs from the Artifact Stores stack to set up permission sets
     with:
       AWS_REGION: us-east-1
       PULUMI_STACK_NAME: prod

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 # Using Pulumi
 Run a Pulumi Preview for the IaC Management project: `uv run python -m aws_central_infrastructure.deploy_iac_management --stack=prod`
+Run a Pulumi Preview for the Artifact Stores project: `uv run python -m aws_central_infrastructure.deploy_artifact_stores --stack=prod`
 Run a Pulumi Preview for the Identity Center project: `uv run python -m aws_central_infrastructure.deploy_identity_center --stack=prod`
 
 

--- a/src/aws_central_infrastructure/artifact_stores/lib/__init__.py
+++ b/src/aws_central_infrastructure/artifact_stores/lib/__init__.py
@@ -1,0 +1,1 @@
+from .program import pulumi_program

--- a/src/aws_central_infrastructure/artifact_stores/lib/program.py
+++ b/src/aws_central_infrastructure/artifact_stores/lib/program.py
@@ -1,9 +1,16 @@
 import logging
 
+from pulumi import export
+
+from .ssm_buckets import ManualArtifactsBucket
+
 logger = logging.getLogger(__name__)
 
 
 def pulumi_program() -> None:
     """Execute creating the stack."""
-
     # Create Resources Here
+    manual_artifacts_bucket = ManualArtifactsBucket()
+    export(
+        "manual-artifacts-bucket-name", manual_artifacts_bucket.bucket.bucket_name
+    )  # referenced by the Identity Center stack

--- a/src/aws_central_infrastructure/artifact_stores/lib/program.py
+++ b/src/aws_central_infrastructure/artifact_stores/lib/program.py
@@ -2,6 +2,7 @@ import logging
 
 from pulumi import export
 
+from .ssm_buckets import DistributorPackagesBucket
 from .ssm_buckets import ManualArtifactsBucket
 
 logger = logging.getLogger(__name__)
@@ -11,6 +12,8 @@ def pulumi_program() -> None:
     """Execute creating the stack."""
     # Create Resources Here
     manual_artifacts_bucket = ManualArtifactsBucket()
+    _ = DistributorPackagesBucket()
+
     export(
         "manual-artifacts-bucket-name", manual_artifacts_bucket.bucket.bucket_name
     )  # referenced by the Identity Center stack

--- a/src/aws_central_infrastructure/artifact_stores/lib/program.py
+++ b/src/aws_central_infrastructure/artifact_stores/lib/program.py
@@ -1,0 +1,9 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def pulumi_program() -> None:
+    """Execute creating the stack."""
+
+    # Create Resources Here

--- a/src/aws_central_infrastructure/artifact_stores/lib/ssm_buckets.py
+++ b/src/aws_central_infrastructure/artifact_stores/lib/ssm_buckets.py
@@ -14,32 +14,34 @@ from pulumi_aws_native import s3
 logger = logging.getLogger(__name__)
 
 
+def create_worm_bucket(*, resource_name: str, parent: ComponentResource) -> s3.Bucket:
+    return s3.Bucket(
+        append_resource_suffix(resource_name),
+        versioning_configuration=s3.BucketVersioningConfigurationArgs(
+            status=s3.BucketVersioningConfigurationStatus.ENABLED
+        ),
+        object_lock_enabled=True,
+        object_lock_configuration=s3.BucketObjectLockConfigurationArgs(
+            object_lock_enabled="Enabled",
+            rule=s3.BucketObjectLockRuleArgs(
+                default_retention=s3.BucketDefaultRetentionArgs(mode=s3.BucketDefaultRetentionMode.GOVERNANCE, years=10)
+            ),
+        ),
+        opts=ResourceOptions(parent=parent),
+        tags=common_tags_native(),
+    )
+
+
 class ManualArtifactsBucket(ComponentResource):
     def __init__(
         self,
     ):
         super().__init__("labauto:ManualArtifactsBucket", append_resource_suffix(), None)
         # These artifacts are deployed to machines and devices. It's too much of a security risk to let people overwrite them, so setting up WORM.
-        self.bucket = s3.Bucket(
-            append_resource_suffix("manual-artifacts"),
-            versioning_configuration=s3.BucketVersioningConfigurationArgs(
-                status=s3.BucketVersioningConfigurationStatus.ENABLED
-            ),
-            object_lock_enabled=True,
-            object_lock_configuration=s3.BucketObjectLockConfigurationArgs(
-                object_lock_enabled="Enabled",
-                rule=s3.BucketObjectLockRuleArgs(
-                    default_retention=s3.BucketDefaultRetentionArgs(
-                        mode=s3.BucketDefaultRetentionMode.GOVERNANCE, years=10
-                    )
-                ),
-            ),
-            opts=ResourceOptions(parent=self),
-            tags=common_tags_native(),
-        )
+        self.bucket = create_worm_bucket(resource_name="manual-artifacts", parent=self)
         org_id = get_organization().id
         _ = s3.BucketPolicy(
-            "bucket-policy",
+            append_resource_suffix("manual-artifacts"),
             bucket=self.bucket.bucket_name,  # type: ignore[reportArgumentType] # pyright somehow thinks a bucket name can be Output[None], which doesn't seem possible
             policy_document=get_policy_document(
                 statements=[
@@ -48,7 +50,7 @@ class ManualArtifactsBucket(ComponentResource):
                         actions=["s3:PutObject", "s3:GetObject", "s3:ListBucket"],
                         principals=[
                             GetPolicyDocumentStatementPrincipalArgs(
-                                type="*",
+                                type="*",  # TODO: consider locking this down to just people for PutObject
                                 identifiers=[
                                     "*"
                                 ],  # Anyone can do anything with this bucket if they themselves have been granted permission. WORM model keeps files secure.
@@ -57,12 +59,77 @@ class ManualArtifactsBucket(ComponentResource):
                         resources=["*"],
                         conditions=[
                             GetPolicyDocumentStatementConditionArgs(
+                                values=[org_id],
                                 test="StringEquals",
                                 variable="aws:PrincipalOrgID",
-                                values=[org_id],  # Limit to the AWS Organization
                             ),
                         ],
                     ),
                 ]
             ).json,
+        )
+
+
+class DistributorPackagesBucket(ComponentResource):
+    def __init__(
+        self,
+    ):
+        super().__init__("labauto:SsmDistributorPackagesBucket", append_resource_suffix(), None)
+        # These artifacts are deployed to machines and devices. It's too much of a security risk to let people overwrite them, so setting up WORM.
+        self.bucket = create_worm_bucket(resource_name="ssm-distributor-packages", parent=self)
+        org_id = get_organization().id
+        _ = s3.BucketPolicy(
+            append_resource_suffix("distributor-packages"),
+            bucket=self.bucket.bucket_name,  # type: ignore[reportArgumentType] # pyright somehow thinks a bucket name can be Output[None], which doesn't seem possible
+            policy_document=self.bucket.bucket_name.apply(
+                lambda bucket_name: get_policy_document(
+                    statements=[
+                        GetPolicyDocumentStatementArgs(
+                            effect="Allow",
+                            actions=["s3:PutObject", "s3:GetObject"],
+                            principals=[
+                                GetPolicyDocumentStatementPrincipalArgs(
+                                    type="AWS",
+                                    identifiers=[
+                                        "*:role/InfraDeploy*",
+                                        "*:role/InfraPreview*",
+                                    ],
+                                )
+                            ],
+                            conditions=[
+                                GetPolicyDocumentStatementConditionArgs(
+                                    variable="aws:PrincipalOrgID",
+                                    test="StringEquals",
+                                    values=[org_id],
+                                ),
+                            ],
+                            resources=[f"arn:aws:s3:::{bucket_name}/${{aws:PrincipalAccount}}/*"],
+                        ),
+                        GetPolicyDocumentStatementArgs(
+                            effect="Allow",
+                            actions=["s3:ListBucket"],
+                            principals=[
+                                GetPolicyDocumentStatementPrincipalArgs(
+                                    type="AWS",
+                                    identifiers=[
+                                        "*:role/InfraDeploy*",
+                                        "*:role/InfraPreview*",
+                                    ],
+                                )
+                            ],
+                            resources=[f"arn:aws:s3:::{bucket_name}"],
+                            conditions=[
+                                GetPolicyDocumentStatementConditionArgs(
+                                    variable="aws:PrincipalOrgID",
+                                    test="StringEquals",
+                                    values=[org_id],
+                                ),
+                                GetPolicyDocumentStatementConditionArgs(
+                                    test="StringLike", variable="s3:prefix", values=["${aws:PrincipalAccount}/*"]
+                                ),
+                            ],
+                        ),
+                    ]
+                ).json
+            ),
         )

--- a/src/aws_central_infrastructure/artifact_stores/lib/ssm_buckets.py
+++ b/src/aws_central_infrastructure/artifact_stores/lib/ssm_buckets.py
@@ -1,0 +1,68 @@
+import logging
+
+from ephemeral_pulumi_deploy import append_resource_suffix
+from ephemeral_pulumi_deploy import common_tags_native
+from pulumi import ComponentResource
+from pulumi import ResourceOptions
+from pulumi_aws.iam import GetPolicyDocumentStatementArgs
+from pulumi_aws.iam import GetPolicyDocumentStatementConditionArgs
+from pulumi_aws.iam import GetPolicyDocumentStatementPrincipalArgs
+from pulumi_aws.iam import get_policy_document
+from pulumi_aws.organizations import get_organization
+from pulumi_aws_native import s3
+
+logger = logging.getLogger(__name__)
+
+
+class ManualArtifactsBucket(ComponentResource):
+    def __init__(
+        self,
+    ):
+        super().__init__("labauto:ManualArtifactsBucket", append_resource_suffix(), None)
+        # These artifacts are deployed to machines and devices. It's too much of a security risk to let people overwrite them, so setting up WORM.
+        self.bucket = s3.Bucket(
+            append_resource_suffix("manual-artifacts"),
+            versioning_configuration=s3.BucketVersioningConfigurationArgs(
+                status=s3.BucketVersioningConfigurationStatus.ENABLED
+            ),
+            object_lock_enabled=True,
+            object_lock_configuration=s3.BucketObjectLockConfigurationArgs(
+                object_lock_enabled="Enabled",
+                rule=s3.BucketObjectLockRuleArgs(
+                    default_retention=s3.BucketDefaultRetentionArgs(
+                        mode=s3.BucketDefaultRetentionMode.GOVERNANCE, years=10
+                    )
+                ),
+            ),
+            opts=ResourceOptions(parent=self),
+            tags=common_tags_native(),
+        )
+        org_id = get_organization().id
+        _ = s3.BucketPolicy(
+            "bucket-policy",
+            bucket=self.bucket.bucket_name,  # type: ignore[reportArgumentType] # pyright somehow thinks a bucket name can be Output[None], which doesn't seem possible
+            policy_document=get_policy_document(
+                statements=[
+                    GetPolicyDocumentStatementArgs(
+                        effect="Allow",
+                        actions=["s3:PutObject", "s3:GetObject", "s3:ListBucket"],
+                        principals=[
+                            GetPolicyDocumentStatementPrincipalArgs(
+                                type="*",
+                                identifiers=[
+                                    "*"
+                                ],  # Anyone can do anything with this bucket if they themselves have been granted permission. WORM model keeps files secure.
+                            )
+                        ],
+                        resources=["*"],
+                        conditions=[
+                            GetPolicyDocumentStatementConditionArgs(
+                                test="StringEquals",
+                                variable="aws:PrincipalOrgID",
+                                values=[org_id],  # Limit to the AWS Organization
+                            ),
+                        ],
+                    ),
+                ]
+            ).json,
+        )

--- a/src/aws_central_infrastructure/deploy_artifact_stores.py
+++ b/src/aws_central_infrastructure/deploy_artifact_stores.py
@@ -1,0 +1,30 @@
+import logging
+from typing import Any
+
+from ephemeral_pulumi_deploy import run_cli
+from pulumi.automation import ConfigValue
+
+from .artifact_stores.lib import pulumi_program
+
+logger = logging.getLogger(__name__)
+
+
+# pylint:disable=duplicate-code # there's not much to DRY up here, it's some commonalities between the two deploy scripts
+def generate_stack_config() -> dict[str, Any]:
+    """Generate the stack configuration."""
+    stack_config: dict[str, Any] = {}
+    stack_config["proj:pulumi_project_name"] = "artifact-stores"
+    stack_config["proj:aws_org_home_region"] = ConfigValue(value="us-east-1")
+    github_repo_name = "aws-central-infrastructure"
+    stack_config["proj:github_repo_name"] = github_repo_name
+
+    stack_config["proj:git_repository_url"] = ConfigValue(value=f"https://github.com/ejfine/{github_repo_name}")
+    return stack_config
+
+
+def main() -> None:
+    run_cli(stack_config=generate_stack_config(), pulumi_program=pulumi_program)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aws_central_infrastructure/iac_management/lib/program.py
+++ b/src/aws_central_infrastructure/iac_management/lib/program.py
@@ -1,5 +1,6 @@
 import logging
 
+from ephemeral_pulumi_deploy import append_resource_suffix
 from ephemeral_pulumi_deploy import get_aws_account_id
 from ephemeral_pulumi_deploy import get_config
 from ephemeral_pulumi_deploy import get_config_str
@@ -29,7 +30,7 @@ def pulumi_program() -> None:
     central_state_bucket_name = get_config_str("proj:backend_bucket_name")
     kmy_key_arn = get_config_str("proj:kms_key_id")
     _ = s3.BucketPolicy(
-        "bucket-policy",
+        append_resource_suffix("central-iac-state"),
         bucket=central_state_bucket_name,
         policy_document=create_bucket_policy(central_state_bucket_name),
     )


### PR DESCRIPTION
 ## Why is this change necessary?
Need buckets to hold SSM Distributor Packages


 ## How does this change address the issue?
Pulls in updates from upstream template to create them


 ## What side effects does this change have?
None


 ## How is this change tested?
Isn't
