### PR TITLE
Exclude the Central Infra workload itself from standard workload management

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.5-1-g72bf311
+_commit: v0.0.5-2-gf49fd7b
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_org_home_region: us-east-1

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.5-2-gf49fd7b
+_commit: v0.0.5-3-g45a97ae
 _src_path: gh:LabAutomationAndScreening/copier-aws-central-infrastructure.git
 aws_identity_center_id: d-9067c20053
 aws_org_home_region: us-east-1

--- a/src/aws_central_infrastructure/iac_management/lib/program.py
+++ b/src/aws_central_infrastructure/iac_management/lib/program.py
@@ -40,8 +40,6 @@ def pulumi_program() -> None:
     workloads_dict, params_dict = load_workload_info()
     providers: dict[AwsAccountId, Provider] = {}
     for workload_info in workloads_dict.values():
-        if workload_info.name == "central-infra":
-            continue  # don't bootstrap the Central Infra 'workload'---it's unique and has been bootstrapped already by the AWS Organization stack
         bootstrap = AwsWorkloadPulumiBootstrap(
             workload=workload_info,
             central_state_bucket_name=central_state_bucket_name,

--- a/src/aws_central_infrastructure/identity_center/lib/program.py
+++ b/src/aws_central_infrastructure/identity_center/lib/program.py
@@ -20,7 +20,7 @@ def pulumi_program() -> None:
     export("aws-account-id", aws_account_id)
 
     # Create Resources Here
-    workloads_dict, _ = load_workload_info()
+    workloads_dict, _ = load_workload_info(exclude_central_infra_workload=False)
     # Note: you must create any new users and deploy them before you can assign any permissions to them (otherwise the Preview will fail)
     create_users()
     create_permissions(workloads_dict)


### PR DESCRIPTION
 ## Why is this change necessary?
The Central Infra "workload" is unique and can't be managed in the same provider role pattern as all the other workloads.


 ## How does this change address the issue?
Excludes it by default from the `load_workload_info` function


 ## What side effects does this change have?
None


 ## How is this change tested?
Isn't
