### PR TITLE
temporarily destroy central networking resources

### DIFF
--- a/src/aws_central_infrastructure/central_networking/lib/program.py
+++ b/src/aws_central_infrastructure/central_networking/lib/program.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 def pulumi_program() -> None:
     """Execute creating the stack."""
     # Create Resources Here
+    return
     all_providers = AllAccountProviders()
     org_info = get_organization()
 


### PR DESCRIPTION
There was a major refactor, and we need to destroy it before pulling in the updtae